### PR TITLE
prevent duplicate concurrent opens of a journal

### DIFF
--- a/clerk/__init__.py
+++ b/clerk/__init__.py
@@ -1,2 +1,2 @@
 """Manage your daily journals"""
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/clerk/app.py
+++ b/clerk/app.py
@@ -7,7 +7,6 @@ import pathlib
 import shutil
 import subprocess
 import sys
-import tempfile
 from typing import Callable
 from typing import Sequence
 from typing import Mapping

--- a/clerk/app.py
+++ b/clerk/app.py
@@ -109,7 +109,7 @@ class Application:
                 f.truncate()
 
     def open_journal(self, filename: str):
-        """Opens the specified journal, calling appropriate Hooks along the way"""
+        """Opens the specified journal for writing, calling appropriate Hooks along the way, and handles eventual write or discard."""
         file_to_open: pathlib.Path = pathlib.Path(self.journal_directory, filename)
         temporary_copy: pathlib.Path = pathlib.Path(self.temp_directory, filename)
         if temporary_copy.exists():

--- a/clerk/config.py
+++ b/clerk/config.py
@@ -18,6 +18,11 @@ def config_file_path() -> Path:
     return Path(dirs().user_config_dir) / "clerk.conf"
 
 
+def temp_directory_path() -> Path:
+    """Returns the path to user's clerk data directory"""
+    return Path(dirs().user_data_dir, dir) / "clerk.conf"
+
+
 def get_config() -> Mapping:
     """Returns the configuration for the clerk application"""
     config_file = config_file_path()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = josephhaaga-clerk
-version = 0.0.5
+version = 0.0.6
 author = Joseph Haaga
 author_email = haaga.joe@gmail.com
 description = A CLI to manage daily journal entries

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = josephhaaga-clerk
-version = 0.0.3
+version = 0.0.4
 author = Joseph Haaga
 author_email = haaga.joe@gmail.com
 description = A CLI to manage daily journal entries

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -49,11 +49,9 @@ def test_application_open_journal(patched_subprocess_run, example_app):
 
 def test_application_wont_open_duplicate(user_data_dir, example_app):
     """Ensure Application.open_journal wont open multiple copies of a file concurrently."""
-    filename = "12345.md"
-    with patch("pathlib.Path.exists", return_value=True):
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            example_app.open_journal(filename)
-
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        with tempfile.NamedTemporaryFile(dir=example_app.temp_directory) as t:
+            example_app.open_journal(t.name)
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
 

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -42,25 +42,17 @@ def example_app(user_data_dir):
 @patch("subprocess.run")
 def test_application_open_journal(patched_subprocess_run, example_app):
     """Ensure Application.open_journal calls subprocess.run"""
-    with tempfile.TemporaryDirectory() as some_dir:
-        filename = "1234.md"
-        existing_journal = pathlib.Path(some_dir, filename)
-        f = open(existing_journal, "a")
-        f.write("Now the file has more content!")
-        f.close()
-        example_app.open_journal(filename)
+    filename = "1234.md"
+    example_app.open_journal(filename)
     patched_subprocess_run.assert_called_once()
 
 
 def test_application_wont_open_duplicate(user_data_dir, example_app):
     """Ensure Application.open_journal wont open multiple copies of a file concurrently."""
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        filename = "12345.md"
-        existing_journal = pathlib.Path(user_data_dir, filename)
-        f = open(existing_journal, "a")
-        f.write("Now the file has more content!")
-        f.close()
-        example_app.open_journal(filename)
+    filename = "12345.md"
+    with patch("pathlib.Path.exists", return_value=True):
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            example_app.open_journal(filename)
 
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1


### PR DESCRIPTION
this should resolve #13 by checking whether the journal is already open

removes dependency on `tempfile` in the application source (it's still used in tests though)