### PR TITLE
allow tilde in config

### DIFF
--- a/clerk/config.py
+++ b/clerk/config.py
@@ -29,6 +29,9 @@ def get_config() -> Mapping:
     config_file.touch(exist_ok=True)
     conf = ConfigParser()
     conf.read(config_file)
+    conf["DEFAULT"]["journal_directory"] = str(
+        Path(conf["DEFAULT"]["journal_directory"]).expanduser()
+    )
     return conf
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = josephhaaga-clerk
-version = 0.0.10
+version = 0.0.11
 author = Joseph Haaga
 author_email = haaga.joe@gmail.com
 description = A CLI to manage daily journal entries

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -25,6 +25,19 @@ def test_get_config_returns_mapping():
     assert isinstance(got, Mapping)
 
 
+@patch("pathlib.Path.expanduser")
+@patch("clerk.config.config_file_path")
+def test_get_config_expands_journal_directory(patched_config_file_path, patched_expand_user):
+    """Ensure clerk.config.get_config expands journal_directory into an absolute path."""
+    patched_expand_user.return_value = "/Users/clerk-user"
+    with NamedTemporaryFile() as f:
+        with open(f.name, "w") as fs:
+            fs.write("[DEFAULT]\njournal_directory=~/some/journals/dir")
+        patched_config_file_path.return_value = Path(f.name)
+        conf = get_config()
+        assert conf["DEFAULT"]["journal_directory"] == "/Users/clerk-user/some/journals/dir"
+
+
 @patch("clerk.config.config_file_path")
 def test_write_config_writes_successfully(patched_config_file_path):
     """Ensure clerk.config.write_config updates the config file"""

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -27,15 +27,20 @@ def test_get_config_returns_mapping():
 
 @patch("pathlib.Path.expanduser")
 @patch("clerk.config.config_file_path")
-def test_get_config_expands_journal_directory(patched_config_file_path, patched_expand_user):
+def test_get_config_expands_journal_directory(
+    patched_config_file_path, patched_expand_user
+):
     """Ensure clerk.config.get_config expands journal_directory into an absolute path."""
-    patched_expand_user.return_value = "/Users/clerk-user"
+    patched_expand_user.return_value = "/Users/clerk-user/some/journals/dir"
     with NamedTemporaryFile() as f:
         with open(f.name, "w") as fs:
             fs.write("[DEFAULT]\njournal_directory=~/some/journals/dir")
         patched_config_file_path.return_value = Path(f.name)
         conf = get_config()
-        assert conf["DEFAULT"]["journal_directory"] == "/Users/clerk-user/some/journals/dir"
+        assert (
+            conf["DEFAULT"]["journal_directory"]
+            == "/Users/clerk-user/some/journals/dir"
+        )
 
 
 @patch("clerk.config.config_file_path")


### PR DESCRIPTION
now the `journal_directory` config item in `.clerkrc` can include `~` instead of an absolute path

closes #21 

this means my `.clerkrc` will be evergreen across computers with different usernames :)